### PR TITLE
Fix typo when downloading elasticsearch_exporter binary to tmp

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
       become: false
       get_url:
         url: "https://github.com/justwatchcom/elasticsearch_exporter/releases/download/v{{ es_exporter_version }}/elasticsearch_exporter-{{ es_exporter_version }}.linux-{{ go_arch }}.tar.gz"
-        dest: "/tmp/elasticsearch_exporter-v{{ es_exporter_version }}.linux-{{ go_arch }}.tar.gz"
+        dest: "/tmp/elasticsearch_exporter-{{ es_exporter_version }}.linux-{{ go_arch }}.tar.gz"
         checksum: "sha256:{{ es_exporter_checksum }}"
       register: _download_binary
       until: _download_binary is success


### PR DESCRIPTION
Connects to https://github.com/be99inner/ansible-elasticsearch-exporter/issues/1